### PR TITLE
Update linear algebra utils and move to Lacaml extension library

### DIFF
--- a/mclang/README.md
+++ b/mclang/README.md
@@ -136,7 +136,7 @@ The Lacaml library is refered to as `lacaml` in dune files -- [dune file link](h
 
 #### Lacamlext
 
-[Lacamlext](/mclang/lib/lacamlext) is a custom-made library which extends the Lacaml library to include more functions.
+[Lacamlext](/mclang/lib/lacamlext) is a custom-made library which extends the Lacaml library to include more functions. To use the the library, include `open Lacamlext;;` at the very beginning of any file which using the Lacaml module.
 
 ##### Functions
 

--- a/mclang/README.md
+++ b/mclang/README.md
@@ -12,8 +12,9 @@
    1. [File Organization](#file-organization)
    2. [Libraries](#libraries)
       1. [Lacaml](#lacaml-1)
-      2. [Complexenv (Cenv)](#complexenv-cenv)
-      3. [Created Dune Libraries](#created-dune-libraries)
+      1. [Lacamlext](#lacamlext)
+      1. [Complexenv (Cenv)](#complexenv-cenv)
+      1. [Created Dune Libraries](#created-dune-libraries)
    3. [Test Cases](#test-cases)
       1. [Running Tests](#running-tests)
       2. [Creating Tests](#creating-tests)
@@ -32,7 +33,8 @@
 
 ### Quick Start
 
-#### Linux 
+#### Linux
+
 The following commands worked to install all needed dependencies on Ubuntu 20.04:
 
 ```
@@ -45,6 +47,7 @@ sudo apt-get install libblas-dev liblapack-dev
 ```
 
 ### MacOS
+
 It's recommended to use package manager [Homebrew](https://brew.sh/) to download dependencies that aren't reliant on Opam.
 Translating the quick start above, this looks like:
 
@@ -59,9 +62,9 @@ brew install openblas lapack
 
 Note that MacOS comes pre installed with the [vecLib framework](https://developer.apple.com/documentation/accelerate/veclib) which
 already contains both BLAS and LAPACK. You can point this project to those pre-existing installations, or download a fresh
-set. 
+set.
 
-When cloning the repository, be sure to pull in all submodules with it by running `git submodule update --init --recursive`. 
+When cloning the repository, be sure to pull in all submodules with it by running `git submodule update --init --recursive`.
 
 More detail is available in the following sections.
 
@@ -130,6 +133,30 @@ We primarily rely on the [Lacaml.Z](http://mmottl.github.io/lacaml/api/lacaml/La
 - [Lacam.Z.Mat](http://mmottl.github.io/lacaml/api/lacaml/Lacaml/Z/Mat/index.html): creating and performing operations on matrices
 
 The Lacaml library is refered to as `lacaml` in dune files -- [dune file link](https://github.com/mmottl/lacaml/blob/master/src/dune).
+
+#### Lacamlext
+
+[Lacamlext](/mclang/lib/lacamlext) is a custom-made library which extends the Lacaml library to include more functions.
+
+##### Functions
+
+- Scalar Multiplication<br>
+  `Lacaml.Z.Vec` and `Lacaml.Z.Mat` are extended to include scalar multiplication functions which multiply each element of a vector or matrix by a complex scalar:<br>
+  - `val scal_mul : Complex.t -> Vec.t -> Vec.t`
+  - `val scal_mul : Complex.t -> Mat.t -> Mat.t`
+- Tensor Product
+  `Lacaml.Z.Vec` and `Lacaml.Z.Mat` are extended to include tensor product functions:<br>
+
+  - `val tensor_prod : Vec.t -> Vec.t -> Vec.t`
+  - `val tensor_prod : Mat.t -> Mat.t -> Mat.t`
+  - `val tensor_prod_list : Vec.t list -> Vec.t`
+  - `val tensor_prod_list : Mat.t list -> Mat.t`
+  - `val tensor_prod_arr : Vec.t array -> Vec.t`
+  - `val tensor_prod_arr : Mat.t array -> Mat.t`
+
+  `tensor_prod` calculates the tensor product between two vectors or two matrices; i.e., x<sub>1</sub> &otimes; x<sub>2</sub>.
+
+  `tensor_prod_list` and `tensor_prod_arr` produces the tensor product of multiple vectors or matrices, evaluating the list or array from left to right; i.e., x<sub>1</sub> &otimes; x<sub>2</sub> &otimes; &hellip; &otimes; x<sub>n</sub>.
 
 #### Complexenv (Cenv)
 

--- a/mclang/backend/run.ml
+++ b/mclang/backend/run.ml
@@ -472,29 +472,6 @@ let eval ((preps, cmds) as p : prog) : bool list = (
 
 let foobar() = (
   print_endline("-- foobar test --");
-  let open Cenv in (
-    let t = Mat.of_array [|
-      [| c 1. 0.; c 2. 0. |];
-      [| c 0. 0.; c (1.) 0. |];
-    |] in
-    let a = Mat.of_array [|
-      [| c 2. 0.; c 3. 1.5 |];
-      [| c 1. 2.; c (-.5.) 0. |];
-    |] in
-    let a' = Mat.scal_mul (c 2. 0.) a in (
-      printf "one = @[%a@]@\n@\n" pp_cmat t;
-      printf "a = @[%a@]@\n@\n" pp_cmat a;
-      printf "a' = @[%a@]@\n@\n" pp_cmat a';
-      printf "one (x) a = @[%a@]@\n@\n" pp_cmat (Mat.tensor_prod t a)
-    );
-    let v1 = Vec.of_array [| c 1. 0.; c 2. 0.; c 3. 0.; |] in
-    let v2 = Vec.of_array [| c 1. 0.; c 2. 0.; |] in
-    let t = Vec.tensor_prod v1 v2 in (
-      printf "v1 = @[%a@]@\n@\n" pp_cvec v1;
-      printf "v2 = @[%a@]@\n@\n" pp_cvec v2;
-      printf "v1 (x) v2 = @[%a@]@\n@\n" pp_cvec t;
-    )
-  );
   let p = ([Init0(0); Init1(1); InitMinus(2); Init(3, 0.375324); InitNonInput([4; 5])], 
             [Entangle(1, 0); Measure(1, 0.0, [], []); XCorrect(0, [])]) 
   in let _ = eval p in ()

--- a/mclang/backend/run.ml
+++ b/mclang/backend/run.ml
@@ -7,6 +7,8 @@
 
 
 open Types;;
+
+open Lacamlext;;
 open Lacaml.Z;;
 
 open Format;;     (* for testing/debugging *)
@@ -60,9 +62,12 @@ let minus_state = (
   |]
 );;
 
+(*
 let controlled_z = (
 
 )
+*)
+
 let dummy_vector = ( (* used for testing only *)
   let open Cenv in 
   Vec.of_array [|
@@ -368,55 +373,6 @@ let print_states (states : Vec.t array) = (
 );;
 
 
-(* *** Linear Algebra Utils -- will probably put in separate file later *** *)
-
-(**
-  * Performs scalar multiplication on vector `v` by scalar `s`
-  *)
-(*
-let vec_scal_mul (v : Vec.t) (s : Complex.t) : Vec.t = (
-  Vec.map (fun e -> Cenv.(e * s)) v
-);;
-*)
-
-(**
-  * Performs scalar multiplication on matrix `m` by scalar `s`
-  *)
-let mat_scal_mul (m : Mat.t) (s : Complex.t) : Mat.t = (
-  Mat.map (fun e -> Cenv.(e * s)) m
-);;
-
-(**
-  * Calculates the tensor product of two vectors
-  *)
-let vec_tensor_prod v1 v2 = (
-  let open Vec in
-  let n = dim v2 in
-  let m = dim v1 in
-  let arr = Array.make m empty in
-  let _ = fold (fun i e -> arr.(i) <- (mul (make n e) v2); i+1) 0 v1 in
-  Array.fold_left (fun v1 v2 -> append v1 v2) empty arr
-);;
-
-(**
-  * Calculates the tensor product of two matrices
-  *)
-let mat_tensor_prod m1 m2 = (
-  let open Mat in
-  let m1_arr = Array.concat (Array.to_list (to_array m1)) in
-  let m2_arr = Array.concat (Array.to_list (to_array m2)) in
-  let m1_rows = dim1 m1 in
-  let m1_cols = dim2 m1 in
-  let m2_rows = dim1 m2 in
-  let m2_cols = dim2 m2 in
-  let rows = m1_rows * m2_rows in
-  let cols = m1_cols * m2_cols in
-  let calc_m1_index = fun r c -> ((c-1) / m2_cols) + m1_cols * ((r-1) / m2_rows) in
-  let calc_m2_index = fun r c -> ((c-1) mod m2_cols) + m2_rows * ((r-1) mod m1_rows) in
-  init_rows rows cols (fun row col -> Cenv.(m1_arr.(calc_m1_index row col) * m2_arr.(calc_m2_index row col)))
-);;
-
-
 (**********************************************************************************
   *                                                                               *
   *                             Evaluation Functions                              *
@@ -525,15 +481,15 @@ let foobar() = (
       [| c 2. 0.; c 3. 1.5 |];
       [| c 1. 2.; c (-.5.) 0. |];
     |] in
-    let a' = mat_scal_mul a (c 2. 0.) in (
+    let a' = Mat.scal_mul (c 2. 0.) a in (
       printf "one = @[%a@]@\n@\n" pp_cmat t;
       printf "a = @[%a@]@\n@\n" pp_cmat a;
       printf "a' = @[%a@]@\n@\n" pp_cmat a';
-      printf "one (x) a = @[%a@]@\n@\n" pp_cmat (mat_tensor_prod t a)
+      printf "one (x) a = @[%a@]@\n@\n" pp_cmat (Mat.tensor_prod t a)
     );
     let v1 = Vec.of_array [| c 1. 0.; c 2. 0.; c 3. 0.; |] in
     let v2 = Vec.of_array [| c 1. 0.; c 2. 0.; |] in
-    let t = vec_tensor_prod v1 v2 in (
+    let t = Vec.tensor_prod v1 v2 in (
       printf "v1 = @[%a@]@\n@\n" pp_cvec v1;
       printf "v2 = @[%a@]@\n@\n" pp_cvec v2;
       printf "v1 (x) v2 = @[%a@]@\n@\n" pp_cvec t;

--- a/mclang/backend/run.ml
+++ b/mclang/backend/run.ml
@@ -389,11 +389,33 @@ let mat_scal_mul (m : Mat.t) (s : Complex.t) : Mat.t = (
 (**
   * Calculates the tensor product of two vectors
   *)
-let tensor_prod v1 v2 = (
+let vec_tensor_prod v1 v2 = (
   let open Vec in
   let n = dim v2 in
-  concat (List.rev (fold (fun ls e -> (mul (make n e) v2)::ls) [] v1))
+  let m = dim v1 in
+  let arr = Array.make m empty in
+  let _ = fold (fun i e -> arr.(i) <- (mul (make n e) v2); i+1) 0 v1 in
+  Array.fold_left (fun v1 v2 -> append v1 v2) empty arr
 );;
+
+(**
+  * Calculates the tensor product of two matrices
+  *)
+let mat_tensor_prod m1 m2 = (
+  let open Mat in
+  let m1_arr = Array.concat (Array.to_list (to_array m1)) in
+  let m2_arr = Array.concat (Array.to_list (to_array m2)) in
+  let m1_rows = dim1 m1 in
+  let m1_cols = dim2 m1 in
+  let m2_rows = dim1 m2 in
+  let m2_cols = dim2 m2 in
+  let rows = m1_rows * m2_rows in
+  let cols = m1_cols * m2_cols in
+  let calc_m1_index = fun r c -> ((c-1) / m2_cols) + m1_cols * ((r-1) / m2_rows) in
+  let calc_m2_index = fun r c -> ((c-1) mod m2_cols) + m2_rows * ((r-1) mod m1_rows) in
+  init_rows rows cols (fun row col -> Cenv.(m1_arr.(calc_m1_index row col) * m2_arr.(calc_m2_index row col)))
+);;
+
 
 (**********************************************************************************
   *                                                                               *
@@ -495,23 +517,26 @@ let eval ((preps, cmds) as p : prog) : bool list = (
 let foobar() = (
   print_endline("-- foobar test --");
   let open Cenv in (
-    let a =
-      Mat.of_array
-        [|
-          [| c 2. 0.; c 3. 1.5 |];
-          [| c 1. 2.; c (-.5.) 0. |];
-        |]
-    in
+    let t = Mat.of_array [|
+      [| c 1. 0.; c 2. 0. |];
+      [| c 0. 0.; c (1.) 0. |];
+    |] in
+    let a = Mat.of_array [|
+      [| c 2. 0.; c 3. 1.5 |];
+      [| c 1. 2.; c (-.5.) 0. |];
+    |] in
     let a' = mat_scal_mul a (c 2. 0.) in (
+      printf "one = @[%a@]@\n@\n" pp_cmat t;
       printf "a = @[%a@]@\n@\n" pp_cmat a;
-      printf "a' = @[%a@]@\n@\n" pp_cmat a'
+      printf "a' = @[%a@]@\n@\n" pp_cmat a';
+      printf "one (x) a = @[%a@]@\n@\n" pp_cmat (mat_tensor_prod t a)
     );
     let v1 = Vec.of_array [| c 1. 0.; c 2. 0.; c 3. 0.; |] in
     let v2 = Vec.of_array [| c 1. 0.; c 2. 0.; |] in
-    let t = tensor_prod v1 v2 in (
+    let t = vec_tensor_prod v1 v2 in (
       printf "v1 = @[%a@]@\n@\n" pp_cvec v1;
       printf "v2 = @[%a@]@\n@\n" pp_cvec v2;
-      printf "v1 (x) v2 = @[%a@]@\n@\n" pp_cvec t
+      printf "v1 (x) v2 = @[%a@]@\n@\n" pp_cvec t;
     )
   );
   let p = ([Init0(0); Init1(1); InitMinus(2); Init(3, 0.375324); InitNonInput([4; 5])], 

--- a/mclang/dune
+++ b/mclang/dune
@@ -11,6 +11,7 @@
   (name linalg)
   (modules)
   (libraries 
+    (re_export lacamlext)
     (re_export lacaml)
     (re_export cenv)
   )

--- a/mclang/lib/complexenv/cenv.ml
+++ b/mclang/lib/complexenv/cenv.ml
@@ -35,8 +35,6 @@ let ( * )   = mul;; (* Multiplication *)
 let ( / )   = div;; (* Division *)
 
 (**
-  * Creates new operator for quick exponentiation.
-  * 
   * x ** y = Complex.pow x y
   * I.e., x to the power of y 
   *)

--- a/mclang/lib/lacamlext/dune
+++ b/mclang/lib/lacamlext/dune
@@ -1,0 +1,5 @@
+
+(library
+  (name lacamlext)
+  (libraries lacaml)
+)

--- a/mclang/lib/lacamlext/lacamlext.ml
+++ b/mclang/lib/lacamlext/lacamlext.ml
@@ -8,6 +8,10 @@ module Lacaml = struct
     module Vec = struct
       include Lacaml.Z.Vec
 
+      let print v = (
+        Format.printf "@[%a@]@\n@\n" Io.pp_cvec v;
+      );;
+
       (**
         * Performs scalar multiplication on vector `v` by scalar `s`
         *)
@@ -26,10 +30,24 @@ module Lacaml = struct
         Array.fold_left (fun v1 v2 -> append v1 v2) empty arr
       );;
 
+      let tensor_prod_list vs = (
+        let open Complex in
+        List.fold_left tensor_prod (make 1 { re = 1.; im = 0.; }) vs
+      );;
+      
+      let tensor_prod_arr vs = (
+        let open Complex in
+        Array.fold_left tensor_prod (make 1 { re = 1.; im = 0.; }) vs
+      );;
+
     end
 
     module Mat = struct
       include Lacaml.Z.Mat
+
+      let print m = (
+        Format.printf "@[%a@]@\n@\n" Io.pp_cmat m;
+      );;
 
       (**
         * Performs scalar multiplication on matrix `m` by scalar `s`
@@ -51,8 +69,19 @@ module Lacaml = struct
         let rows = m1_rows * m2_rows in
         let cols = m1_cols * m2_cols in
         let calc_m1_index = fun r c -> ((c-1) / m2_cols) + m1_cols * ((r-1) / m2_rows) in
-        let calc_m2_index = fun r c -> ((c-1) mod m2_cols) + m2_rows * ((r-1) mod m1_rows) in
+        let calc_m2_index = fun r c -> ((c-1) mod m2_cols) + m2_rows * ((r-1) mod m2_rows) in
         init_rows rows cols (fun row col -> Complex.mul (m1_arr.(calc_m1_index row col)) (m2_arr.(calc_m2_index row col)))
+        (* init_rows rows cols (fun row col -> { Complex.re = (Int.to_float (calc_m1_index row col)); im = (Int.to_float (calc_m2_index row col)); }) (* for debugging *) *)
+      );;
+
+      let tensor_prod_list ms = (
+        let open Complex in
+        List.fold_left tensor_prod (make 1 1 { re = 1.; im = 0.; }) ms
+      );;
+      
+      let tensor_prod_arr ms = (
+        let open Complex in
+        Array.fold_left tensor_prod (make 1 1 { re = 1.; im = 0.; }) ms
       );;
 
     end  

--- a/mclang/lib/lacamlext/lacamlext.ml
+++ b/mclang/lib/lacamlext/lacamlext.ml
@@ -1,0 +1,60 @@
+(* Linear Algebra Utils *)
+
+module Lacaml = struct
+  include Lacaml
+  module Z = struct
+    include Lacaml.Z
+    
+    module Vec = struct
+      include Lacaml.Z.Vec
+
+      (**
+        * Performs scalar multiplication on vector `v` by scalar `s`
+        *)
+      let scal_mul (s : Complex.t) (v : Vec.t) : Vec.t = (
+        map (fun e -> Complex.mul e s) v
+      );;
+
+      (**
+        * Calculates the tensor product of two vectors
+        *)
+      let tensor_prod v1 v2 = (
+        let n = dim v2 in
+        let m = dim v1 in
+        let arr = Array.make m empty in
+        let _ = fold (fun i e -> arr.(i) <- (mul (make n e) v2); i+1) 0 v1 in
+        Array.fold_left (fun v1 v2 -> append v1 v2) empty arr
+      );;
+
+    end
+
+    module Mat = struct
+      include Lacaml.Z.Mat
+
+      (**
+        * Performs scalar multiplication on matrix `m` by scalar `s`
+        *)
+      let scal_mul (s : Complex.t) (m : Mat.t) : Mat.t = (
+        map (fun e -> Complex.mul e s) m
+      );;
+
+      (**
+        * Calculates the tensor product of two matrices
+        *)
+      let tensor_prod m1 m2 = (
+        let m1_arr = Array.concat (Array.to_list (to_array m1)) in
+        let m2_arr = Array.concat (Array.to_list (to_array m2)) in
+        let m1_rows = dim1 m1 in
+        let m1_cols = dim2 m1 in
+        let m2_rows = dim1 m2 in
+        let m2_cols = dim2 m2 in
+        let rows = m1_rows * m2_rows in
+        let cols = m1_cols * m2_cols in
+        let calc_m1_index = fun r c -> ((c-1) / m2_cols) + m1_cols * ((r-1) / m2_rows) in
+        let calc_m2_index = fun r c -> ((c-1) mod m2_cols) + m2_rows * ((r-1) mod m1_rows) in
+        init_rows rows cols (fun row col -> Complex.mul (m1_arr.(calc_m1_index row col)) (m2_arr.(calc_m2_index row col)))
+      );;
+
+    end  
+  end
+end;;

--- a/mclang/tests/la/dune
+++ b/mclang/tests/la/dune
@@ -1,6 +1,13 @@
 ;; Linear Algebra Tests
 
 (tests
-  (names basic complex cenv1)
+  (names 
+    basic 
+    complex 
+    cenv1 
+    scal_mul 
+    tensor_prod 
+    tensor_prod_list
+  )
   (libraries mcl linalg)
 )

--- a/mclang/tests/la/scal_mul.ml
+++ b/mclang/tests/la/scal_mul.ml
@@ -1,0 +1,16 @@
+open Lacamlext;;
+open Lacaml.Z;;
+
+open Format;;
+open Lacaml.Io;;
+
+let () = let open Cenv in (
+  let a = Mat.of_array [|
+    [| c 2. 0.; c 3. 1.5 |];
+    [| c 1. 2.; c (-.5.) 0. |];
+  |] in
+  let a' = Mat.scal_mul (c 2. 0.) a in (
+    printf "a = @[%a@]@\n@\n" pp_cmat a;
+    printf "a' = @[%a@]@\n@\n" pp_cmat a';
+  )
+);;

--- a/mclang/tests/la/tensor_prod.ml
+++ b/mclang/tests/la/tensor_prod.ml
@@ -1,0 +1,27 @@
+open Lacamlext;;
+open Lacaml.Z;;
+
+open Format;;
+open Lacaml.Io;;
+
+let () = let open Cenv in (
+  let t = Mat.of_array [|
+    [| c 1. 0.; c 2. 0. |];
+    [| c 0. 0.; c (1.) 0. |];
+  |] in
+  let a = Mat.of_array [|
+    [| c 2. 0.; c 3. 1.5 |];
+    [| c 1. 2.; c (-.5.) 0. |];
+  |] in (
+    printf "t = @[%a@]@\n@\n" pp_cmat t;
+    printf "a = @[%a@]@\n@\n" pp_cmat a;
+    printf "t (x) a = @[%a@]@\n@\n" pp_cmat (Mat.tensor_prod t a)
+  );
+  let v1 = Vec.of_array [| c 1. 0.; c 2. 0.; c 3. 0.; |] in
+  let v2 = Vec.of_array [| c 1. 0.; c 2. 0.; |] in
+  let t = Vec.tensor_prod v1 v2 in (
+    printf "v1 = @[%a@]@\n@\n" pp_cvec v1;
+    printf "v2 = @[%a@]@\n@\n" pp_cvec v2;
+    printf "v1 (x) v2 = @[%a@]@\n@\n" pp_cvec t;
+  )
+);;

--- a/mclang/tests/la/tensor_prod_list.ml
+++ b/mclang/tests/la/tensor_prod_list.ml
@@ -1,0 +1,28 @@
+open Lacamlext;;
+open Lacaml.Z;;
+
+open Format;;
+open Lacaml.Io;;
+
+let () = let open Cenv in (
+  let a1 = Mat.of_array [|
+    [| c 1. 0.; c 2. 0. |];
+    [| c 0. 0.; c (1.) 0. |];
+  |] in
+  let a2 = Mat.of_array [|
+    [| c 2. 0.; c 3. 1.5 |];
+    [| c 1. 2.; c (-.5.) 0. |];
+  |] in (
+    printf "a1 = @[%a@]@\n@\n" pp_cmat a1;
+    printf "a2 = @[%a@]@\n@\n" pp_cmat a2;
+    printf "a1 (x) a2 = @[%a@]@\n@\n" pp_cmat (Mat.tensor_prod_list [a1; a2]);
+    printf "a1 (x) a1 (x) a2 = @[%a@]@\n@\n" pp_cmat (Mat.tensor_prod_arr [|a1; a1; a2|])
+  );
+  let v1 = Vec.of_array [| c 1. 0.; c 2. 0.; c 3. 0.; |] in
+  let v2 = Vec.of_array [| c 1. 0.; c 2. 0.; |] in (
+    printf "v1 = @[%a@]@\n@\n" pp_cvec v1;
+    printf "v2 = @[%a@]@\n@\n" pp_cvec v2;
+    printf "v1 (x) v2 = @[%a@]@\n@\n" pp_cvec (Vec.tensor_prod_arr [|v1; v2|]);
+    printf "v1 (x) v2 (x) v2 = @[%a@]@\n@\n" pp_cvec (Vec.tensor_prod_list [v1; v2; v2])
+  )
+);;


### PR DESCRIPTION
Move linear algebra utils in run.ml to an external library when extends lacaml